### PR TITLE
usb: fix msos string descriptor

### DIFF
--- a/hw/usb/desc-msos.c
+++ b/hw/usb/desc-msos.c
@@ -1,6 +1,7 @@
 #include "qemu/osdep.h"
 #include "hw/usb.h"
 #include "desc.h"
+#include "desc-msos.h"
 
 /*
  * Microsoft OS Descriptors
@@ -28,7 +29,42 @@
  *
  * http://msdn.microsoft.com/en-us/library/windows/hardware/ff537430.aspx
  *
+ *
+ * Microsoft OS 1.0 Descriptors Specification (OS_Desc_Intro.doc)
+ * (https://download.microsoft.com/download/9/C/5/9C5B2167-8017-4BAE-9FDE-D599BAC8184A/OS_Desc_Ext_Prop.zip)
+ *
  */
+
+/* ------------------------------------------------------------------ */
+/* Table 3. OS String Descriptor Fields (OS_Desc_Intro.doc)           */
+typedef struct msos_str_desc {
+    uint8_t  bLength;
+    uint8_t  bDescriptorType;
+    uint16_t qwSignature[7];
+    uint8_t  bMS_VendorCode;
+    uint8_t  bPad;
+} QEMU_PACKED msos_str_desc;
+
+int usb_desc_msos_str_desc(const char* str, uint8_t *dest, uint8_t ven_code)
+{
+    msos_str_desc *str_desc = (msos_str_desc *)dest;
+    const int len = strlen(str);
+    assert(7 == len);
+
+    str_desc->bLength = sizeof(msos_str_desc);
+    str_desc->bDescriptorType = USB_DT_STRING;
+    str_desc->qwSignature[0] = (uint16_t)str[0];
+    str_desc->qwSignature[1] = (uint16_t)str[1];
+    str_desc->qwSignature[2] = (uint16_t)str[2];
+    str_desc->qwSignature[3] = (uint16_t)str[3];
+    str_desc->qwSignature[4] = (uint16_t)str[4];
+    str_desc->qwSignature[5] = (uint16_t)str[5];
+    str_desc->qwSignature[6] = (uint16_t)str[6];
+    str_desc->bMS_VendorCode = ven_code;
+    str_desc->bPad = 0x00;
+
+    return sizeof(msos_str_desc);
+}
 
 /* ------------------------------------------------------------------ */
 

--- a/hw/usb/desc-msos.h
+++ b/hw/usb/desc-msos.h
@@ -1,0 +1,12 @@
+#ifndef QEMU_HW_USB_DESC_MSOS_H
+#define QEMU_HW_USB_DESC_MSOS_H
+
+/* Microsoft OS 1.0 Descriptors Specification (OS_Desc_Intro.doc)
+ * (https://download.microsoft.com/download/9/C/5/9C5B2167-8017-4BAE-9FDE-D599BAC8184A/OS_Desc_Ext_Prop.zip)
+ */
+#define MSOS_DESC_INDEX (0xee)
+
+/* generate microsoft string descriptor from structs */
+int usb_desc_msos_str_desc(const char* str, uint8_t *dest, uint8_t ven_code);
+
+#endif /* QEMU_HW_USB_DESC_MSOS_H */

--- a/hw/usb/desc.c
+++ b/hw/usb/desc.c
@@ -2,6 +2,7 @@
 
 #include "hw/usb.h"
 #include "desc.h"
+#include "desc-msos.h"
 #include "trace.h"
 
 /* ------------------------------------------------------------------ */
@@ -511,7 +512,7 @@ void usb_desc_init(USBDevice *dev)
     }
     if (desc->msos && (dev->flags & (1 << USB_DEV_FLAG_MSOS_DESC_ENABLE))) {
         dev->flags |= (1 << USB_DEV_FLAG_MSOS_DESC_IN_USE);
-        usb_desc_set_string(dev, 0xee, "MSFT100Q");
+        usb_desc_set_string(dev, MSOS_DESC_INDEX, "MSFT100");
     }
     usb_desc_setdefaults(dev);
 }
@@ -605,6 +606,14 @@ int usb_desc_string(USBDevice *dev, int index, uint8_t *dest, size_t len)
         dest[2] = 0x09;
         dest[3] = 0x04;
         return 4;
+    }
+
+    if (index == MSOS_DESC_INDEX) {
+        /* language ids */
+        if (dev->flags & (1 << USB_DEV_FLAG_MSOS_DESC_IN_USE)) {
+            str = usb_desc_get_string(dev, index);
+            return usb_desc_msos_str_desc(str, dest, 0x00);
+        }
     }
 
     str = usb_desc_get_string(dev, index);


### PR DESCRIPTION
usb: fix msos string descriptor

MSFT100Q --> MSFT100

The string is a signature with seven wide chars(MSFT100), and should end with two bytes (bMS_VendorCode and bPad).

Signed-off-by: Dougals Chen douglas.chen@genesyslogic.com.tw